### PR TITLE
Fix bug for login with current credential

### DIFF
--- a/EAAutomation.ps1
+++ b/EAAutomation.ps1
@@ -1,10 +1,11 @@
-Import-Module $(Join-Path $PSScriptRoot '.\Utilities.psm1') -Force
+# Import-Module $(Join-Path $PSScriptRoot '.\Utilities.psm1') -Force
+using module .\Utilities.psm1
 
 $global:loginInfo = $null
 $global:configuration = Get-Configuration
 
 function MainMenu {
-  $LoginMenu = Create-Menu -MenuTitle "Welcome to EA Admin Tools - Login" -MenuOptions "Login with User Credential","Login with current User Credential","Login with Service Principal","Quit"
+  $LoginMenu = Create-Menu -MenuTitle "Welcome to EA Admin Tools - Login" -MenuOptions "Login with User Credential","Login with current Credential","Login with Service Principal","Quit"
   switch ($LoginMenu) {
     0 { 
       Login-User
@@ -12,7 +13,11 @@ function MainMenu {
     }
     1 {
       Login-User -SkipLogin
-      Get-UserFunctionMenu
+      if ([CredentialType]::SPN -eq $(Get-CredentialType)) {
+        Get-SPNFunctionMenu
+      } else {
+        Get-UserFunctionMenu
+      }
     }
     2 {
       az login --service-principal -u $global:configuration.SPLoginInfo.Client_Id -p $global:configuration.SPLoginInfo.Client_Password --tenant $global:configuration.SPLoginInfo.Tenant_Id --allow-no-subscriptions

--- a/Utilities.psm1
+++ b/Utilities.psm1
@@ -1,3 +1,9 @@
+enum CredentialType {
+    NotLoggedIn
+    User
+    SPN
+}
+
 function Create-Menu {
   Param(
       [Parameter(Mandatory=$false)][string]  $MenuTitle = $null,
@@ -110,7 +116,6 @@ function Get-AccessToken {
     return $(az account get-access-token --resource=https://management.azure.com --query accessToken --output tsv)
 }
 
-
 function Write-Warning {
     param (
         [Parameter(Mandatory=$true, Position=0)]
@@ -151,6 +156,17 @@ function Write-Error {
     Write-Host $Text -ForegroundColor Red
 }
 
+function Get-CredentialType {
+    if ($null -eq $global:loginInfo) {
+        return [CredentialType]::NotLoggedIn
+    }
+
+    if (Test-IsGuid $global:loginInfo.user.name) {
+        return [CredentialType]::SPN
+    } else {
+        return [CredentialType]::User
+    }
+}
 
 function Get-IsValidEmail {
     param(
@@ -213,8 +229,6 @@ function Choose-YesOrNo {
 
   function Show-UserAndConfigInfo {
     if ($null -ne $global:loginInfo) {
-        # Write-Info "Signed-in Account: $($global:loginInfo.user.name)"
-        # Write-Info "TenantId: $($global:loginInfo.tenantId)"
         Write-Host "Signed-in Account: " -NoNewLine; Write-Host $global:loginInfo.user.name -ForegroundColor DarkGreen
         Write-Host "TenantId: " -NoNewLine; Write-Host $global:loginInfo.tenantId -ForegroundColor DarkGreen
     }
@@ -222,6 +236,10 @@ function Choose-YesOrNo {
     Write-Host "Enrollment Name: " -NoNewline; Write-Host $global:configuration.RoleOperationScope.BillingAccountName -ForegroundColor DarkGreen
     Write-Host "Department Name: " -NoNewline; Write-Host $global:configuration.RoleOperationScope.DepartmentName -ForegroundColor DarkGreen
     Write-Host "Enrollment Account Name: " -NoNewline; Write-Host $global:configuration.RoleOperationScope.EnrollmentAccountName -ForegroundColor DarkGreen
+
+    # # Test with Enum
+    # $credentialType = Get-CredentialType
+    # Write-Host $credentialType
   }
 
 # function New-DataTable {


### PR DESCRIPTION
Previously there is a bug with SkipLogin since once we logged in with SPN, skip login will continue to use the SPN credential. However, this feature meant to be used by user credential cuz shows the User Function Menu afterwards.

Fixed the bug by checking on the logged in credential type and then load correct menu.